### PR TITLE
체결가 데이터 실시간 업데이트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "axios": "^0.27.2",
+    "date-fns": "^2.29.3",
     "eslint": "^8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { DayCandles, MinuteCandles, MonthCandles, Unit, WeekCandles } from '../types/candle';
-import { MarketCodes, Orderbooks, PresentPrices, RecentContracts } from '../types';
+import { MarketCodes, Orderbooks, PresentPrices, Trades } from '../types';
 
 const BASE_URL = 'https://api.upbit.com/v1';
 
@@ -38,7 +38,7 @@ export async function getCandleByMonths(market: string, count: number): Promise<
   return response.data;
 }
 
-export async function getRecentContract(market: string, count: number): Promise<RecentContracts> {
+export async function getTrades(market: string, count: number): Promise<Trades> {
   const query = `/trades/ticks?market=${market}&count=${count}`;
   const response = await axios.get(BASE_URL + query);
   return response.data;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -38,8 +38,8 @@ export async function getCandleByMonths(market: string, count: number): Promise<
   return response.data;
 }
 
-export async function getTrades(market: string, count: number): Promise<Trades> {
-  const query = `/trades/ticks?market=${market}&count=${count}`;
+export async function getTrades(market: string): Promise<Trades> {
+  const query = `/trades/ticks?market=${market}&count=30`;
   const response = await axios.get(BASE_URL + query);
   return response.data;
 }

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -27,7 +27,7 @@ export default function TradeItem({ trade }: TradeItemProps) {
         </i>
       </TradeItemCell>
       <TradeItemCell>{trade.tradePrice.toLocaleString()}</TradeItemCell>
-      <TradeItemCell>{trade.tradeVolume.toFixed(8)}</TradeItemCell>
+      <TradeVolume askbid={trade.askBid}>{trade.tradeVolume.toFixed(8)}</TradeVolume>
       <TradeItemCell>{tradePriceFormat(trade.tradePrice, trade.tradeVolume)}</TradeItemCell>
     </TradeItemRow>
   );
@@ -68,5 +68,12 @@ const TradeItemCell = styled(TableCell)`
   & > i {
     padding-left: 8px;
     color: ${({ theme }) => theme.colors.darkGray};
+  }
+`;
+
+const TradeVolume = styled(TradeItemCell)<{ askbid: 'ASK' | 'BID' }>`
+  && {
+    color: ${({ theme, askbid }) =>
+      askbid === 'BID' ? theme.colors.lightRed : theme.colors.lightBlue};
   }
 `;

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -1,15 +1,27 @@
 import { TableRow, TableCell } from '@mui/material';
 import styled from 'styled-components';
+import { tradePriceFormat } from '../../utils';
 
-export default function TradeItem() {
+interface TradeItemProps {
+  trade: {
+    tradeDate: string;
+    tradeTime: string;
+    tradePrice: number;
+    tradeVolume: number;
+    askBid: 'ASK' | 'BID';
+  };
+}
+
+export default function TradeItem({ trade }: TradeItemProps) {
   return (
     <TradeItemRow>
       <TradeItemCell>
-        11.17<i>16:22</i>
+        {trade.tradeDate}
+        <i>{trade.tradeTime}</i>
       </TradeItemCell>
-      <TradeItemCell>22,260,000</TradeItemCell>
-      <TradeItemCell>0.0000731</TradeItemCell>
-      <TradeItemCell>1,133,122</TradeItemCell>
+      <TradeItemCell>{trade.tradePrice.toLocaleString()}</TradeItemCell>
+      <TradeItemCell>{trade.tradeVolume.toFixed(8)}</TradeItemCell>
+      <TradeItemCell>{tradePriceFormat(trade.tradePrice, trade.tradeVolume)}</TradeItemCell>
     </TradeItemRow>
   );
 }

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -1,11 +1,11 @@
 import { TableRow, TableCell } from '@mui/material';
 import styled from 'styled-components';
 import { tradePriceFormat } from '../../utils';
+import { getMonth, getDate, getHours, getMinutes } from 'date-fns';
 
 interface TradeItemProps {
   trade: {
-    tradeDate: string;
-    tradeTime: string;
+    timestamp: number;
     tradePrice: number;
     tradeVolume: number;
     askBid: 'ASK' | 'BID';
@@ -13,11 +13,18 @@ interface TradeItemProps {
 }
 
 export default function TradeItem({ trade }: TradeItemProps) {
+  const month = getMonth(trade.timestamp) + 1;
+  const date = getDate(trade.timestamp);
+  const hour = getHours(trade.timestamp);
+  const minute = getMinutes(trade.timestamp);
+
   return (
     <TradeItemRow>
       <TradeItemCell>
-        {trade.tradeDate}
-        <i>{trade.tradeTime}</i>
+        {month}.{date}
+        <i>
+          {hour}:{minute}
+        </i>
       </TradeItemCell>
       <TradeItemCell>{trade.tradePrice.toLocaleString()}</TradeItemCell>
       <TradeItemCell>{trade.tradeVolume.toFixed(8)}</TradeItemCell>

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -20,7 +20,7 @@ export default function TradeItem({ trade }: TradeItemProps) {
   const date = getDate(trade.timestamp);
   const hour = getHours(trade.timestamp);
   const minute = getMinutes(trade.timestamp);
-
+  console.log(trade.tradeVolume);
   return (
     <TradeItemRow>
       <TradeItemCell>
@@ -32,7 +32,9 @@ export default function TradeItem({ trade }: TradeItemProps) {
       <TradePrice price={trade.tradePrice - prevClosingPrice}>
         {trade.tradePrice.toLocaleString()}
       </TradePrice>
-      <TradeVolume askbid={trade.askBid}>{trade.tradeVolume.toFixed(8)}</TradeVolume>
+      <TradeVolume askbid={trade.askBid}>
+        {Number(trade.tradeVolume.toFixed(8)).toLocaleString()}
+      </TradeVolume>
       <TradeItemCell>{tradePriceFormat(trade.tradePrice, trade.tradeVolume)}</TradeItemCell>
     </TradeItemRow>
   );

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -20,7 +20,7 @@ export default function TradeItem({ trade }: TradeItemProps) {
   const date = getDate(trade.timestamp);
   const hour = getHours(trade.timestamp);
   const minute = getMinutes(trade.timestamp);
-  console.log(trade.tradeVolume);
+
   return (
     <TradeItemRow>
       <TradeItemCell>

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -2,6 +2,7 @@ import { TableRow, TableCell } from '@mui/material';
 import styled from 'styled-components';
 import { tradePriceFormat } from '../../utils';
 import { getMonth, getDate, getHours, getMinutes } from 'date-fns';
+import { useAppSelector } from '../../store/store';
 
 interface TradeItemProps {
   trade: {
@@ -13,6 +14,8 @@ interface TradeItemProps {
 }
 
 export default function TradeItem({ trade }: TradeItemProps) {
+  const prevClosingPrice = useAppSelector((state) => state.coin.selectedCoin.prevClosingPrice);
+
   const month = getMonth(trade.timestamp) + 1;
   const date = getDate(trade.timestamp);
   const hour = getHours(trade.timestamp);
@@ -26,7 +29,9 @@ export default function TradeItem({ trade }: TradeItemProps) {
           {hour}:{minute}
         </i>
       </TradeItemCell>
-      <TradeItemCell>{trade.tradePrice.toLocaleString()}</TradeItemCell>
+      <TradePrice price={trade.tradePrice - prevClosingPrice}>
+        {trade.tradePrice.toLocaleString()}
+      </TradePrice>
       <TradeVolume askbid={trade.askBid}>{trade.tradeVolume.toFixed(8)}</TradeVolume>
       <TradeItemCell>{tradePriceFormat(trade.tradePrice, trade.tradeVolume)}</TradeItemCell>
     </TradeItemRow>
@@ -68,6 +73,13 @@ const TradeItemCell = styled(TableCell)`
   & > i {
     padding-left: 8px;
     color: ${({ theme }) => theme.colors.darkGray};
+  }
+`;
+
+const TradePrice = styled(TradeItemCell)<{ price: number }>`
+  && {
+    color: ${({ theme, price }) =>
+      price > 0 ? theme.colors.lightRed : price < 0 ? theme.colors.lightBlue : 'black'};
   }
 `;
 

--- a/src/components/TradeItem/index.tsx
+++ b/src/components/TradeItem/index.tsx
@@ -33,7 +33,9 @@ export default function TradeItem({ trade }: TradeItemProps) {
         {trade.tradePrice.toLocaleString()}
       </TradePrice>
       <TradeVolume askbid={trade.askBid}>
-        {Number(trade.tradeVolume.toFixed(8)).toLocaleString()}
+        {Number(trade.tradeVolume.toFixed(8)).toLocaleString(undefined, {
+          minimumFractionDigits: 8,
+        })}
       </TradeVolume>
       <TradeItemCell>{tradePriceFormat(trade.tradePrice, trade.tradeVolume)}</TradeItemCell>
     </TradeItemRow>

--- a/src/components/TradeList/index.tsx
+++ b/src/components/TradeList/index.tsx
@@ -45,12 +45,12 @@ export default function TradeList() {
               {trades.length > 0
                 ? trades.map((trade) => (
                     <TradeItem
-                      key={trade.sequential_id}
+                      key={trade.sequentialId}
                       trade={{
                         timestamp: trade.timestamp,
-                        tradePrice: trade.trade_price,
-                        tradeVolume: trade.trade_volume,
-                        askBid: trade.ask_bid,
+                        tradePrice: trade.tradePrice,
+                        tradeVolume: trade.tradeVolume,
+                        askBid: trade.askBid,
                       }}
                     />
                   ))

--- a/src/components/TradeList/index.tsx
+++ b/src/components/TradeList/index.tsx
@@ -9,12 +9,14 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import styled from 'styled-components';
+import { useAppSelector } from '../../store/store';
 import TradeItem from '../TradeItem';
 
 const tabList = ['체결', '일별'];
 
 export default function TradeList() {
   const [selectedTab, setSelectedTab] = useState<number>(0);
+  const trades = useAppSelector((state) => state.coin.tradeList);
 
   const handleTabClick = (index: number) => setSelectedTab(index);
 
@@ -39,10 +41,19 @@ export default function TradeList() {
               </TradeListRow>
             </TableHead>
             <TableBody>
-              <TradeItem />
-              <TradeItem />
-
-              <TradeItem />
+              {trades.length > 0
+                ? trades.map((trade) => (
+                    <TradeItem
+                      key={trade.sequential_id}
+                      trade={{
+                        timestamp: trade.timestamp,
+                        tradePrice: trade.trade_price,
+                        tradeVolume: trade.trade_volume,
+                        askBid: trade.ask_bid,
+                      }}
+                    />
+                  ))
+                : null}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/TradeList/index.tsx
+++ b/src/components/TradeList/index.tsx
@@ -16,6 +16,7 @@ const tabList = ['체결', '일별'];
 
 export default function TradeList() {
   const [selectedTab, setSelectedTab] = useState<number>(0);
+  const code = useAppSelector((state) => state.coin.selectedCoin.code);
   const trades = useAppSelector((state) => state.coin.tradeList);
 
   const handleTabClick = (index: number) => setSelectedTab(index);
@@ -36,7 +37,7 @@ export default function TradeList() {
               <TradeListRow>
                 <TradeListCell>체결시간</TradeListCell>
                 <TradeListCell>체결가격(KRW)</TradeListCell>
-                <TradeListCell>체결량(BTC)</TradeListCell>
+                <TradeListCell>체결량({code.substring(4)})</TradeListCell>
                 <TradeListCell>체결금액(KRW)</TradeListCell>
               </TradeListRow>
             </TableHead>

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { MarketCodes, Orderbooks, PresentPrices } from '../../types';
+import { MarketCodes, Orderbooks, PresentPrices, Trades } from '../../types';
 import { RealTimeOrderbooks, RealTimeTickers, RealTimeTrades } from '../../types/realTime';
 import { CoinState } from '../../types/state';
 
@@ -40,6 +40,10 @@ const initialState: CoinState = {
   loadTickerListLoading: false,
   loadTickerListDone: false,
   loadTickerListError: null,
+
+  loadTradeListLoading: false,
+  loadTradeListDone: false,
+  loadTradeListError: null,
 
   loadOrderbookLoading: false,
   loadOrderbookDone: false,
@@ -100,6 +104,21 @@ const coinSlice = createSlice({
     loadTickerListFailure: (state, { payload }) => {
       state.loadTickerListLoading = false;
       state.loadTickerListError = payload.error;
+    },
+    loadTradeListRequest: (state) => {
+      state.loadTradeListLoading = true;
+      state.loadTradeListDone = false;
+      state.loadTradeListError = null;
+    },
+    loadTradeListSuccess: (state, { payload }: PayloadAction<Trades>) => {
+      state.loadTradeListLoading = false;
+      state.loadTradeListDone = true;
+
+      state.tradeList = payload.reverse();
+    },
+    loadTradeListFailure: (state, { payload }) => {
+      state.loadTradeListLoading = false;
+      state.loadTradeListError = payload.error;
     },
     loadOrderbookRequest: (state) => {
       state.loadOrderbookLoading = true;
@@ -235,6 +254,9 @@ export const {
   loadTickerListRequest,
   loadTickerListSuccess,
   loadTickerListFailure,
+  loadTradeListRequest,
+  loadTradeListSuccess,
+  loadTradeListFailure,
   loadOrderbookRequest,
   loadOrderbookSuccess,
   loadOrderbookFailure,

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -114,7 +114,20 @@ const coinSlice = createSlice({
       state.loadTradeListLoading = false;
       state.loadTradeListDone = true;
 
-      state.tradeList = payload;
+      payload.forEach((trade) => {
+        state.tradeList.push({
+          market: trade.market,
+          tradeDateUtc: trade.trade_date_utc,
+          tradeTimeUtc: trade.trade_time_utc,
+          timestamp: trade.timestamp,
+          tradePrice: trade.trade_price,
+          tradeVolume: trade.trade_volume,
+          prevClosingPrice: trade.prev_closing_price,
+          changePrice: trade.change_price,
+          askBid: trade.ask_bid,
+          sequentialId: trade.sequential_id,
+        });
+      });
     },
     loadTradeListFailure: (state, { payload }) => {
       state.loadTradeListLoading = false;
@@ -193,12 +206,31 @@ const coinSlice = createSlice({
       });
     },
     updateTradeList: (state, { payload }: PayloadAction<RealTimeTrades>) => {
-      const tradeList = [
-        ...state.tradeList,
-        ...payload.filter((trade) => trade.code === state.selectedCoin.code),
-      ];
+      // const tradeList = [
+      //   ...state.tradeList,
+      //   ...payload.filter((trade) => trade.code === state.selectedCoin.code),
+      // ];
 
-      state.tradeList = state.tradeList.slice(-tradeList.length);
+      const tradeList = payload.filter((trade) => trade.code === state.selectedCoin.code);
+
+      tradeList.forEach((trade) => {
+        state.tradeList.unshift({
+          market: trade.code,
+          tradeDateUtc: trade.trade_date,
+          tradeTimeUtc: trade.trade_time,
+          timestamp: trade.timestamp,
+          tradePrice: trade.trade_price,
+          tradeVolume: trade.trade_volume,
+          prevClosingPrice: trade.prev_closing_price,
+          changePrice: trade.change_price,
+          askBid: trade.ask_bid,
+          sequentialId: trade.sequential_id,
+        });
+      });
+
+      console.log(tradeList);
+
+      // state.tradeList = state.tradeList.slice(-tradeList.length);
     },
 
     updateOrderbook: (state, { payload }: PayloadAction<RealTimeOrderbooks>) => {

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -114,6 +114,8 @@ const coinSlice = createSlice({
       state.loadTradeListLoading = false;
       state.loadTradeListDone = true;
 
+      state.tradeList = [];
+
       payload.forEach((trade) => {
         state.tradeList.push({
           market: trade.market,

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -114,7 +114,7 @@ const coinSlice = createSlice({
       state.loadTradeListLoading = false;
       state.loadTradeListDone = true;
 
-      state.tradeList = payload.reverse();
+      state.tradeList = payload;
     },
     loadTradeListFailure: (state, { payload }) => {
       state.loadTradeListLoading = false;

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -193,7 +193,6 @@ const coinSlice = createSlice({
           }) === i
         );
       });
-
       // 코인별 현재가 state 업데이트
       tickerList.forEach((ticker, index) => {
         state.tickerList[tickerList[index].code] = {
@@ -206,33 +205,28 @@ const coinSlice = createSlice({
       });
     },
     updateTradeList: (state, { payload }: PayloadAction<RealTimeTrades>) => {
-      // const tradeList = [
-      //   ...state.tradeList,
-      //   ...payload.filter((trade) => trade.code === state.selectedCoin.code),
-      // ];
-
+      // 중복으로 들어온 코드 제거
       const tradeList = payload.filter((trade) => trade.code === state.selectedCoin.code);
 
+      // 들어온 데이터가 기존데이터에 존재할 경우 업데이트 안함
       tradeList.forEach((trade) => {
-        state.tradeList.unshift({
-          market: trade.code,
-          tradeDateUtc: trade.trade_date,
-          tradeTimeUtc: trade.trade_time,
-          timestamp: trade.timestamp,
-          tradePrice: trade.trade_price,
-          tradeVolume: trade.trade_volume,
-          prevClosingPrice: trade.prev_closing_price,
-          changePrice: trade.change_price,
-          askBid: trade.ask_bid,
-          sequentialId: trade.sequential_id,
-        });
+        if (!state.tradeList.find((value) => value.sequentialId === trade.sequential_id)) {
+          state.tradeList.unshift({
+            market: trade.code,
+            tradeDateUtc: trade.trade_date,
+            tradeTimeUtc: trade.trade_time,
+            timestamp: trade.timestamp,
+            tradePrice: trade.trade_price,
+            tradeVolume: trade.trade_volume,
+            prevClosingPrice: trade.prev_closing_price,
+            changePrice: trade.change_price,
+            askBid: trade.ask_bid,
+            sequentialId: trade.sequential_id,
+          });
+          state.tradeList.pop();
+        }
       });
-
-      console.log(tradeList);
-
-      // state.tradeList = state.tradeList.slice(-tradeList.length);
     },
-
     updateOrderbook: (state, { payload }: PayloadAction<RealTimeOrderbooks>) => {
       // 마지막 호가 데이터로 업데이트
       const codes = payload.map((orderbook) => orderbook.code);

--- a/src/store/modules/coin.ts
+++ b/src/store/modules/coin.ts
@@ -1,12 +1,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { MarketCodes, Orderbooks, PresentPrices } from '../../types';
-import { RealTimeOrderbooks, RealTimeTickers } from '../../types/realTime';
+import { RealTimeOrderbooks, RealTimeTickers, RealTimeTrades } from '../../types/realTime';
 import { CoinState } from '../../types/state';
 
 const initialState: CoinState = {
   marketList: [],
 
   tickerList: {},
+
+  tradeList: [],
 
   orderbook: {
     timestamp: 0,
@@ -171,6 +173,15 @@ const coinSlice = createSlice({
         };
       });
     },
+    updateTradeList: (state, { payload }: PayloadAction<RealTimeTrades>) => {
+      const tradeList = [
+        ...state.tradeList,
+        ...payload.filter((trade) => trade.code === state.selectedCoin.code),
+      ];
+
+      state.tradeList = state.tradeList.slice(-tradeList.length);
+    },
+
     updateOrderbook: (state, { payload }: PayloadAction<RealTimeOrderbooks>) => {
       // 마지막 호가 데이터로 업데이트
       const codes = payload.map((orderbook) => orderbook.code);
@@ -231,6 +242,7 @@ export const {
   loadSelectedCoinDataSuccess,
   loadSelectedCoinDataFailure,
   updateTickerList,
+  updateTradeList,
   updateOrderbook,
   updateSelectedCoin,
   changeSelectedCoin,

--- a/src/store/sagas/index.ts
+++ b/src/store/sagas/index.ts
@@ -27,7 +27,7 @@ function* initSaga() {
 
   yield put(presentPriceSocketRequest({ codes: markets })); // 현재가 소켓 연결 요청
 
-  // yield put(tradeSocketRequest({ codes: ['KRW-BTC'] })); // 체결가 소켓 연결 요청
+  yield put(tradeSocketRequest({ codes: markets })); // 체결가 소켓 연결 요청
   yield put(orderbookSocketRequest({ codes: markets })); // 호가 소켓 연결 요청
 }
 

--- a/src/store/sagas/index.ts
+++ b/src/store/sagas/index.ts
@@ -11,6 +11,7 @@ import coinSaga, {
   loadOrderbookSaga,
   loadSelectedCoinDataSaga,
   loadTickerList,
+  loadTradeListSaga,
 } from './coin';
 import socketSaga from './socket';
 
@@ -22,6 +23,7 @@ function* initSaga() {
   const markets = coin.marketList.map((value) => value.code);
 
   yield loadTickerList(markets);
+  yield loadTradeListSaga(coin.selectedCoin.code);
   yield loadOrderbookSaga([coin.selectedCoin.code]);
   yield loadSelectedCoinDataSaga(coin.selectedCoin.code);
 

--- a/src/store/sagas/socket.ts
+++ b/src/store/sagas/socket.ts
@@ -4,7 +4,12 @@ import { all, call, delay, fork, put, takeEvery, flush, select } from 'redux-sag
 import { RealTimeOrderbooks, RealTimeTickers, RealTimeTrades } from '../../types/realTime';
 import RootState from '../../types/state';
 import { createSocket } from '../../utils';
-import { updateOrderbook, updateSelectedCoin, updateTickerList } from '../modules/coin';
+import {
+  updateOrderbook,
+  updateSelectedCoin,
+  updateTickerList,
+  updateTradeList,
+} from '../modules/coin';
 import {
   presentPriceSocketSuccess,
   presentPriceSocketFailure,
@@ -95,9 +100,12 @@ export function* tradeSocketSaga({ payload }: PayloadAction<{ codes: string[] }>
 
     while (true) {
       const msg: RealTimeTrades = yield flush(channel);
+      const {
+        coin: { selectedCoin },
+      }: RootState = yield select();
 
-      if (msg.length) {
-        console.log(msg);
+      if (msg.length && msg.find((value) => value.code === selectedCoin.code)) {
+        yield put(updateTradeList(msg));
       }
       yield delay(500); // 0.5초마다 업데이트
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export interface Trade {
   trade_volume: number;
   prev_closing_price: number;
   change_price: number;
-  ask_bid: string;
+  ask_bid: 'ASK' | 'BID';
   sequential_id: number;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export interface MarketCode {
 
 export type MarketCodes = MarketCode[];
 
-export interface RecentContract {
+export interface Trade {
   market: string;
   trade_date_utc: string;
   trade_time_utc: string;
@@ -20,7 +20,7 @@ export interface RecentContract {
   sequential_id?: number;
 }
 
-export type RecentContracts = RecentContract[];
+export type Trades = Trade[];
 
 export interface PresentPrice {
   market: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,7 @@ export interface Trade {
   prev_closing_price: number;
   change_price: number;
   ask_bid: string;
-  sequential_id?: number;
+  sequential_id: number;
 }
 
 export type Trades = Trade[];

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -31,7 +31,18 @@ export interface CoinState {
     };
   };
 
-  tradeList: Trades;
+  tradeList: {
+    market: string;
+    tradeDateUtc: string;
+    tradeTimeUtc: string;
+    timestamp: number;
+    tradePrice: number;
+    tradeVolume: number;
+    prevClosingPrice: number;
+    changePrice: number;
+    askBid: 'ASK' | 'BID';
+    sequentialId: number;
+  }[];
 
   orderbook: {
     timestamp: number;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,5 +1,4 @@
-import { Orderbooks } from '.';
-import { RealTimeTrades } from './realTime';
+import { Trades } from '.';
 
 export interface SocketState {
   presentPriceSocketLoading: boolean;
@@ -32,7 +31,7 @@ export interface CoinState {
     };
   };
 
-  tradeList: RealTimeTrades;
+  tradeList: Trades;
 
   orderbook: {
     timestamp: number;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -70,6 +70,10 @@ export interface CoinState {
   loadTickerListDone: boolean;
   loadTickerListError: Error | null;
 
+  loadTradeListLoading: boolean;
+  loadTradeListDone: boolean;
+  loadTradeListError: Error | null;
+
   loadOrderbookLoading: boolean;
   loadOrderbookDone: boolean;
   loadOrderbookError: Error | null;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,4 +1,5 @@
 import { Orderbooks } from '.';
+import { RealTimeTrades } from './realTime';
 
 export interface SocketState {
   presentPriceSocketLoading: boolean;
@@ -30,6 +31,8 @@ export interface CoinState {
       signedChangePrice: number;
     };
   };
+
+  tradeList: RealTimeTrades;
 
   orderbook: {
     timestamp: number;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,6 +27,10 @@ export function tradeVolume24hFormat(tradeVolume24h: number) {
   return Number(tradeVolume24h.toFixed(3)).toLocaleString();
 }
 
+export function tradePriceFormat(tradePrice: number, tradeVolume: number) {
+  return Math.round(tradePrice / (10 / (tradeVolume * 10))).toLocaleString();
+}
+
 export function createSocket(): WebSocket {
   const ws = new WebSocket('wss://api.upbit.com/websocket/v1');
   ws.binaryType = 'arraybuffer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,6 +3855,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# 개요
체결가 데이터 실시간 업데이트 구현

# 내용
웹소켓 데이터로 체결가가 들어오면 체결가 데이터가 업데이트 되게끔 함
체결가 개수 30개만 응답 받게끔 api 수정함
TradeItem 컴포넌트에 쓰일 데이터들을 렌더링 함